### PR TITLE
Feat: Flutter version 3.32.0

### DIFF
--- a/lib/src/bindings/isolate_bindings/absent_scheduler_binding.dart
+++ b/lib/src/bindings/isolate_bindings/absent_scheduler_binding.dart
@@ -84,7 +84,7 @@ mixin _AbsentSchedulerBinding on BindingBase implements SchedulerBinding {
   void scheduleFrame() {}
 
   @override
-  int scheduleFrameCallback(callback, {bool rescheduling = false}) {
+  int scheduleFrameCallback(callback, {bool rescheduling = false, bool scheduleNewFrame = true}) {
     throw UnimplementedError();
   }
 


### PR DESCRIPTION
Fix compatibility with Flutter 3.32.0 #30 

This commit updates the scheduleFrameCallback method signature in the _AbsentSchedulerBinding mixin to match the changes in Flutter 3.32.0. The method now includes the 'scheduleNewFrame' parameter that was added in the newer Flutter version.

The change ensures that the combine package can work properly with Flutter 3.32.0 without causing method signature mismatch errors during runtime.

# PR Checklist

- [x] Code is 100% covered. 
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] Changelog is updated.

